### PR TITLE
feat: Implement shared element transitions and redesign profile screens

### DIFF
--- a/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/components/ChatListItem.kt
+++ b/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/components/ChatListItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -112,13 +113,17 @@ fun ChatListItem(
                         contentScale = ContentScale.Crop,
                         error = rememberAsyncImagePainter(R.drawable.person),
                         modifier = Modifier
-                            .clickable(onClick = {
-                                navController.navigate(
-                                    FullScreenImageViewerDC(
-                                        imageUri = imageUri,
+                            .clickable(
+                                onClick = {
+                                    navController.navigate(
+                                        FullScreenImageViewerDC(
+                                            imageUri = imageUri,
+                                        )
                                     )
-                                )
-                            })
+                                },
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() },
+                            )
                             .sharedBounds(
                                 sharedContentState = rememberSharedContentState(key = "image/$imageUri"),
                                 animatedVisibilityScope = animatedScope
@@ -132,17 +137,25 @@ fun ChatListItem(
                     modifier = Modifier.fillMaxWidth(1f),
                     verticalArrangement = Arrangement.Center
                 ) {
-                    Text(
-                        text = room.otherParticipant.username,
-                        modifier = Modifier.padding(start = 7.dp),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    with(sharedTransitionScope) {
+                        Text(
+                            text = room.otherParticipant.username,
+                            modifier = Modifier
+                                .padding(start = 7.dp)
+                                .sharedBounds(
+                                    sharedContentState = rememberSharedContentState(key = "text/${room.otherParticipant.username}"),
+                                    animatedVisibilityScope = animatedScope
+                                ),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                     if (room.lastMessage.isNotEmpty()) {
                         Text(
-                            text = if (room.lastMessageSenderId == currentUserId) "You: ${room.lastMessage}" else room.lastMessage,
+                            text = if (room.lastMessageSenderId == currentUserId) "You: ${room.lastMessage}"
+                            else room.lastMessage,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(start = 7.dp, end = 10.dp),
                             fontSize = 13.sp,

--- a/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/screens/EditProfileScreen.kt
+++ b/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/screens/EditProfileScreen.kt
@@ -3,30 +3,40 @@ package com.aubynsamuel.flashsend.home.presentation.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularWavyProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Update
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,16 +46,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
@@ -55,20 +69,32 @@ import com.aubynsamuel.flashsend.auth.presentation.viewmodels.AuthViewModel
 import com.aubynsamuel.flashsend.chat.presentation.utils.CropImageContract
 import com.aubynsamuel.flashsend.core.data.CurrentUser
 import com.aubynsamuel.flashsend.core.presentation.utils.showToast
+import com.aubynsamuel.flashsend.navigation.LocalSharedTransitionScope
 import com.aubynsamuel.flashsend.navigation.safePopBackStack
 import com.google.firebase.Firebase
 import com.google.firebase.storage.storage
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlin.math.abs
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun EditProfileScreen(
     navController: NavController,
     authViewModel: AuthViewModel,
+    animatedScope: AnimatedContentScope,
 ) {
-    val userData by CurrentUser.userData.collectAsStateWithLifecycle()
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val density = LocalDensity.current
+    val maxHeight = 220.dp
+    val minHeight = 120.dp
+    val maxHeightPx = with(density) { maxHeight.toPx() }
+    val minHeightPx = with(density) { minHeight.toPx() }
+    val headerHeight = remember { Animatable(maxHeightPx) }
+    val headerHeightDp = with(density) { headerHeight.value.toDp() }
 
+    val userData by CurrentUser.userData.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var username by remember { mutableStateOf(userData?.username ?: "") }
     var profileUri by remember { mutableStateOf<Uri?>(null) }
@@ -91,138 +117,244 @@ fun EditProfileScreen(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp)
-            .padding(top = 20.dp)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Icon(
-            Icons.AutoMirrored.Default.ArrowBack,
-            contentDescription = "",
-            modifier = Modifier
-                .align(Alignment.Start)
-                .clickable(onClick = { navController.safePopBackStack() }),
-            tint = MaterialTheme.colorScheme.onBackground
-        )
-        Text(
-            text = "Edit Profile",
-            fontSize = 25.sp,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-        Spacer(modifier = Modifier.height(10.dp))
-        Text(
-            text = "Update your username and/or profile picture",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(70.dp))
+    fun updateProfile() {
+        if (username.isBlank() && profileUri == null) {
+            showToast(context, "Please update at least one field")
+            return
+        }
+        isLoading = true
+        coroutineScope.launch {
+            try {
+                val newData = mutableMapOf<String, Any>()
 
-        // Profile Picture
-        Box(modifier = Modifier.clickable { imagePickerLauncher.launch("image/*") }) {
-            AsyncImage(
-                model = if (profileUri != null) profileUri else userData?.profileUrl,
-                contentDescription = "Selected image",
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .size(200.dp)
-                    .background(MaterialTheme.colorScheme.surfaceVariant)
-                    .align(Alignment.Center),
-                contentScale = ContentScale.Crop,
-                error = rememberAsyncImagePainter(R.drawable.person)
+                if (username.isNotBlank()) {
+                    newData["username"] = username
+                }
+
+                // Upload new profile picture if selected.
+                if (profileUri != null) {
+                    val imageRef =
+                        storageRef.child("profilePictures/${username}_profile_pic.jpg")
+                    imageRef.putFile(profileUri!!).await()
+                    val profileUrl = imageRef.downloadUrl.await().toString()
+                    newData["profileUrl"] = profileUrl
+                }
+
+                // Update Firestore document if there is at least one field to update.
+                if (newData.isNotEmpty()) {
+                    authViewModel.updateUserDocument(newData)
+                    showToast(context, "Profile updated successfully!")
+                    authViewModel.loadUserData()
+                } else {
+                    showToast(context, "No updates provided")
+                }
+            } catch (e: Exception) {
+                showToast(context, "Error: ${e.message}", true)
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    val exitUntilCollapsedScrollBehavior = remember {
+        object : NestedScrollConnection {
+            private val snapThreshold = (maxHeightPx + minHeightPx) / 2
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+                if (delta < 0f) { // Scroll Up (Collapse)
+                    val previousHeight = headerHeight.value
+                    // Calculate the new height, constrained by min/max
+                    val newHeaderHeight =
+                        (headerHeight.value + delta).coerceIn(minHeightPx, maxHeightPx)
+
+                    // Consumed is the actual change in header height (must be negative)
+                    val consumed = newHeaderHeight - previousHeight
+
+                    if (abs(consumed) > 0.5f) { // Check to prevent tiny floats from consuming
+                        coroutineScope.launch {
+                            headerHeight.animateTo(newHeaderHeight)
+                        }
+                        return Offset(0f, consumed)
+                    }
+                }
+                return Offset.Zero
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                val delta = available.y
+                if (delta > 0f) { // Scroll Down (Expand)
+                    val previousHeight = headerHeight.value
+                    // Calculate the new height, constrained by min/max
+                    val newHeaderHeight =
+                        (headerHeight.value + delta).coerceIn(minHeightPx, maxHeightPx)
+
+                    // Consumed is the actual change in header height (must be positive)
+                    val consumed = newHeaderHeight - previousHeight
+
+                    if (abs(consumed) > 0.5f) {
+                        coroutineScope.launch {
+                            headerHeight.animateTo(newHeaderHeight)
+                        }
+                        return Offset(0f, consumed)
+                    }
+                }
+                return Offset.Zero
+            }
+
+            override suspend fun onPostFling(
+                consumed: Velocity,
+                available: Velocity,
+            ): Velocity {
+                val currentHeight = headerHeight.value
+                val targetHeight = if (currentHeight < snapThreshold) {
+                    minHeightPx
+                } else {
+                    maxHeightPx
+                }
+                if (currentHeight != targetHeight) {
+                    headerHeight.animateTo(targetHeight)
+                }
+                return available
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(exitUntilCollapsedScrollBehavior),
+        topBar = {
+            TopAppBar(
+                title = {
+                    with(sharedTransitionScope) {
+                        Text(
+                            "Edit Profile",
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier.sharedBounds(
+                                sharedContentState = rememberSharedContentState(key = "text/editProfileScreenTitle"),
+                                animatedVisibilityScope = animatedScope
+                            )
+                        )
+                    }
+                },
+                actions = {
+                    with(sharedTransitionScope) {
+                        IconButton(
+                            onClick = { updateProfile() },
+                            modifier = Modifier.sharedBounds(
+                                sharedContentState = rememberSharedContentState(key = "icon/editProfileToProfile"),
+                                animatedVisibilityScope = animatedScope
+                            )
+                        ) {
+                            Icon(Icons.Default.Update, contentDescription = "Edit Profile")
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navController.safePopBackStack() },
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Go to Profile Screen"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors().copy(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
             )
         }
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Choose a profile picture",
-            modifier = Modifier.clickable { imagePickerLauncher.launch("image/*") },
-            color = MaterialTheme.colorScheme.onBackground,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Username Input
-        BasicTextField(
-            value = username,
-            onValueChange = { username = it },
-            textStyle = TextStyle(fontSize = 16.sp),
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Text,
-                capitalization = KeyboardCapitalization.Sentences
-            ),
+    ) { paddingValues ->
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.LightGray, shape = MaterialTheme.shapes.medium)
-                .padding(12.dp),
-            decorationBox = { innerTextField ->
-                Box(
-                    contentAlignment = Alignment.CenterStart,
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .verticalScroll(rememberScrollState())
+                .padding(paddingValues),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Header
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .height(headerHeightDp)
+            ) {
+                with(sharedTransitionScope) {
+                    val imageUri = userData?.profileUrl
+                    AsyncImage(
+                        model = if (profileUri != null) profileUri else userData?.profileUrl,
+                        contentDescription = "Profile picture",
+                        contentScale = ContentScale.Crop,
+                        error = rememberAsyncImagePainter(R.drawable.person),
+                        modifier = Modifier
+                            .clickable(onClick = {
+                                imagePickerLauncher.launch("image/*")
+                            })
+                            .border(
+                                2.dp,
+                                MaterialTheme.colorScheme.primary,
+                                CircleShape
+                            )
+                            .clip(CircleShape)
+                            .size(headerHeightDp - 80.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Text(
+                    text = "Change profile picture",
+                    modifier = Modifier.clickable { imagePickerLauncher.launch("image/*") },
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+
+            // Details
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+            ) {
+                Text("Info", textAlign = TextAlign.Left, fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(10.dp))
+
+                // Username TextField
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(30.dp)
-                        .padding(horizontal = 10.dp)
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (username.isEmpty()) {
-                        Text(text = "Username", color = Color.Gray)
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = "Username",
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Column {
+                        OutlinedTextField(
+                            value = username.ifEmpty { "Username" },
+                            onValueChange = { username = it },
+                            label = { Text("Username") },
+                            shape = RoundedCornerShape(10.dp),
+                            textStyle = MaterialTheme.typography.bodyLarge,
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Text,
+                                capitalization = KeyboardCapitalization.Sentences,
+                                imeAction = ImeAction.Done
+                            ),
+                        )
                     }
-                    innerTextField()
                 }
-            })
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        // Save Button
-        Button(onClick = {
-            if (username.isBlank() && profileUri == null) {
-                showToast(context, "Please update at least one field")
-                return@Button
-            }
-            isLoading = true
-            coroutineScope.launch {
-                try {
-                    val newData = mutableMapOf<String, Any>()
-
-                    if (username.isNotBlank()) {
-                        newData["username"] = username
-                    }
-
-                    // Upload new profile picture if selected.
-                    if (profileUri != null) {
-                        val imageRef =
-                            storageRef.child("profilePictures/${username}_profile_pic.jpg")
-                        imageRef.putFile(profileUri!!).await()
-                        val profileUrl = imageRef.downloadUrl.await().toString()
-                        newData["profileUrl"] = profileUrl
-                    }
-
-                    // Update Firestore document if there is at least one field to update.
-                    if (newData.isNotEmpty()) {
-                        authViewModel.updateUserDocument(newData)
-                        showToast(context, "Profile updated successfully!")
-                        authViewModel.loadUserData()
-                    } else {
-                        showToast(context, "No updates provided")
-                    }
-                } catch (e: Exception) {
-                    showToast(context, "Error: ${e.message}", true)
-                } finally {
-                    isLoading = false
-                }
-            }
-        }) {
-            if (isLoading) {
-                CircularWavyProgressIndicator(
-                    color = Color.White,
-                    modifier = Modifier.size(24.dp)
-                )
-            } else {
-                Text("Save", fontSize = 18.sp)
             }
         }
     }

--- a/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/aubynsamuel/flashsend/home/presentation/screens/ProfileScreen.kt
@@ -2,6 +2,7 @@ package com.aubynsamuel.flashsend.home.presentation.screens
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,31 +14,37 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.ModeEdit
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -49,6 +56,8 @@ import com.aubynsamuel.flashsend.core.presentation.navigation.EditProfileDC
 import com.aubynsamuel.flashsend.core.presentation.navigation.FullScreenImageViewerDC
 import com.aubynsamuel.flashsend.home.presentation.components.ProfileDetailItem
 import com.aubynsamuel.flashsend.navigation.LocalSharedTransitionScope
+import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
@@ -56,38 +65,136 @@ import com.aubynsamuel.flashsend.navigation.LocalSharedTransitionScope
 fun ProfileScreen(
     navController: NavController,
     animatedScope: AnimatedVisibilityScope,
-
-    ) {
+) {
     val userData by CurrentUser.userData.collectAsStateWithLifecycle()
     val sharedTransitionScope = LocalSharedTransitionScope.current
+    val coroutineScope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val maxHeight = 220.dp
+    val minHeight = 120.dp
+    val maxHeightPx = with(density) { maxHeight.toPx() }
+    val minHeightPx = with(density) { minHeight.toPx() }
+    val headerHeight = remember { Animatable(maxHeightPx) }
+    val headerHeightDp = with(density) { headerHeight.value.toDp() }
 
-    Scaffold(topBar = {
-        CenterAlignedTopAppBar(
-            title = { Text("My Profile", fontWeight = FontWeight.Medium) },
-            colors = TopAppBarDefaults.topAppBarColors().copy(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                titleContentColor = MaterialTheme.colorScheme.primary
-            ),
-        )
-    }) { paddingValues ->
+    val exitUntilCollapsedScrollBehavior = remember {
+        object : NestedScrollConnection {
+            private val snapThreshold = (maxHeightPx + minHeightPx) / 2
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+                if (delta < 0f) { // Scroll Up (Collapse)
+                    val previousHeight = headerHeight.value
+                    // Calculate the new height, constrained by min/max
+                    val newHeaderHeight =
+                        (headerHeight.value + delta).coerceIn(minHeightPx, maxHeightPx)
+
+                    // Consumed is the actual change in header height (must be negative)
+                    val consumed = newHeaderHeight - previousHeight
+
+                    if (abs(consumed) > 0.5f) { // Check to prevent tiny floats from consuming
+                        coroutineScope.launch {
+                            headerHeight.animateTo(newHeaderHeight)
+                        }
+                        return Offset(0f, consumed)
+                    }
+                }
+                return Offset.Zero
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                val delta = available.y
+                if (delta > 0f) { // Scroll Down (Expand)
+                    val previousHeight = headerHeight.value
+                    // Calculate the new height, constrained by min/max
+                    val newHeaderHeight =
+                        (headerHeight.value + delta).coerceIn(minHeightPx, maxHeightPx)
+
+                    // Consumed is the actual change in header height (must be positive)
+                    val consumed = newHeaderHeight - previousHeight
+
+                    if (abs(consumed) > 0.5f) {
+                        coroutineScope.launch {
+                            headerHeight.animateTo(newHeaderHeight)
+                        }
+                        return Offset(0f, consumed)
+                    }
+                }
+                return Offset.Zero
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                val currentHeight = headerHeight.value
+                val targetHeight = if (currentHeight < snapThreshold) {
+                    minHeightPx
+                } else {
+                    maxHeightPx
+                }
+                if (currentHeight != targetHeight) {
+                    headerHeight.animateTo(targetHeight)
+                }
+                return available
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(exitUntilCollapsedScrollBehavior),
+        topBar = {
+            TopAppBar(
+                title = {
+                    with(sharedTransitionScope) {
+                        Text(
+                            "Profile",
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier.sharedBounds(
+                                sharedContentState = rememberSharedContentState(key = "text/editProfileScreenTitle"),
+                                animatedVisibilityScope = animatedScope
+                            )
+                        )
+                    }
+                },
+                actions = {
+                    with(sharedTransitionScope) {
+                        IconButton(
+                            onClick = { navController.navigate(EditProfileDC) },
+                            modifier = Modifier.sharedBounds(
+                                sharedContentState = rememberSharedContentState(key = "icon/editProfileToProfile"),
+                                animatedVisibilityScope = animatedScope
+                            )
+                        ) {
+                            Icon(Icons.Default.ModeEdit, contentDescription = "Edit Profile")
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors().copy(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
-                .background(MaterialTheme.colorScheme.background),
+                .background(MaterialTheme.colorScheme.background)
+                .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Profile Header
+            // Header
             Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(200.dp)
-                    .background(
-                        MaterialTheme.colorScheme.primaryContainer,
-                    ),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .height(headerHeightDp)
             ) {
                 // Profile Picture
                 with(sharedTransitionScope) {
@@ -105,63 +212,54 @@ fun ProfileScreen(
                                     )
                                 )
                             })
-                            .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                            .border(
+                                2.dp,
+                                MaterialTheme.colorScheme.primary,
+                                CircleShape
+                            )
                             .sharedBounds(
                                 sharedContentState = rememberSharedContentState(key = "image/${imageUri}"),
                                 animatedVisibilityScope = animatedScope
                             )
                             .clip(CircleShape)
-                            .size(120.dp)
+                            .size(headerHeightDp - 80.dp)
                     )
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(10.dp))
 
                 Text(
                     text = userData?.username ?: "Username",
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier
                 )
-
                 Text(
-                    text = userData?.email ?: "Email",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    text = "Online",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = (0.8f))
                 )
             }
 
-            // Profile Details Card
-            Card(
+            // Details
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                elevation = CardDefaults.cardElevation(8.dp)
+                    .padding(16.dp)
             ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    ProfileDetailItem(
-                        icon = Icons.Default.Person,
-                        label = "Username",
-                        value = userData?.username ?: "Not set"
-                    )
+                Text("Info", textAlign = TextAlign.Left, fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(10.dp))
+                ProfileDetailItem(
+                    icon = Icons.Default.Person,
+                    label = "Username",
+                    value = userData?.username ?: "Not set"
+                )
 
-                    ProfileDetailItem(
-                        icon = Icons.Default.Email,
-                        label = "Email",
-                        value = userData?.email ?: "Not set"
-                    )
-                }
-            }
-
-            // Action Buttons
-            Spacer(modifier = Modifier.height(24.dp))
-
-            FilledTonalButton(
-                onClick = { navController.navigate(EditProfileDC) },
-                modifier = Modifier.fillMaxWidth(0.8f)
-            ) {
-                Icon(Icons.Default.Edit, contentDescription = null)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Edit Profile")
+                ProfileDetailItem(
+                    icon = Icons.Default.Email,
+                    label = "Email",
+                    value = userData?.email ?: "Not set"
+                )
+                Spacer(modifier = Modifier.height(20.dp))
             }
         }
     }


### PR DESCRIPTION

This commit introduces shared element transitions between the Profile and Edit Profile screens for a smoother user experience. It also redesigns both screens with a modern, collapsible header and improved layout.

- **Shared Element Transitions:**
    - Implemented shared transitions for the profile picture, username text, and header elements between the `ProfileScreen` and `EditProfileScreen`.
    - Added shared transition for the user's profile picture and username in the `ChatListItem` on the home screen.

- **Profile Screen Redesign:**
    - Redesigned `ProfileScreen` and `EditProfileScreen` to use a `Scaffold` with a `TopAppBar`.
    - Introduced a collapsible header that shrinks and expands on scroll, creating a dynamic and modern feel.
    - The "Edit Profile" action is now an icon button in the `TopAppBar`.

- **Edit Profile Screen Redesign:**
    - Overhauled the `EditProfileScreen` UI for better organization and aesthetics.
    - Replaced the `BasicTextField` with a styled `OutlinedTextField` for the username.
    - The save functionality is now triggered by an "Update" icon in the `TopAppBar`.